### PR TITLE
Cross platform env

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "postinstall": "./node_modules/.bin/selenium-standalone install && node nightwatch.conf.js",
     "compile": "webpack --progress --profile --colors --hide-modules",
-    "compile:production": "env NODE_ENV=production webpack --colors --hide-modules",
+    "compile:production": "cross-env NODE_ENV=production webpack --colors --hide-modules",
     "start": "webpack-dev-server",
     "test": "BABEL_ENV=es2015 ./node_modules/.bin/nightwatch --group play --env chrome",
     "test:saucelabs": "BABEL=true BABEL_ENV=es2015 ./node_modules/.bin/nightwatch --group play --config nightwatch.conf.sauce.js --env chrome"
@@ -47,7 +47,8 @@
     "redux-thunk": "^2.2.0",
     "selenium-webdriver": "^3.1.0",
     "whatwg-fetch": "^2.0.1",
-    "xml2js": "^0.4.17"
+    "xml2js": "^0.4.17",
+    "cross-env": "^5.0.5"
   },
   "devDependencies": {
     "babel-core": "^6.13.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "postinstall": "./node_modules/.bin/selenium-standalone install && node nightwatch.conf.js",
     "compile": "webpack --progress --profile --colors --hide-modules",
-    "compile:production": "NODE_ENV=production webpack --colors --hide-modules",
+    "compile:production": "env NODE_ENV=production webpack --colors --hide-modules",
     "start": "webpack-dev-server",
     "test": "BABEL_ENV=es2015 ./node_modules/.bin/nightwatch --group play --env chrome",
     "test:saucelabs": "BABEL=true BABEL_ENV=es2015 ./node_modules/.bin/nightwatch --group play --config nightwatch.conf.sauce.js --env chrome"

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,7 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <configuration>
+                    <layout>MODULE</layout>
                     <addResources>true</addResources>
                 </configuration>
             </plugin>


### PR DESCRIPTION
* Genom att specifiera "env" kan både windows och mc köra npm run compile:production
* Pomen har uppdaterats för att stödja gakusei-admin