### PR TITLE
Hide kanji option in navbar dropdown

### DIFF
--- a/src/main/js/screens/app/components/GakuseiNav.js
+++ b/src/main/js/screens/app/components/GakuseiNav.js
@@ -37,9 +37,9 @@ export class GakuseiNav extends React.Component {
                 <LinkContainer to="/select/flashcards">
                   <MenuItem className="flashcardPlay">Bildkort</MenuItem>
                 </LinkContainer>
-                <LinkContainer to="/select/kanji">
+                  {/* <LinkContainer to="/select/kanji">
                   <MenuItem className="kanjiPlay">Skriv Kanji</MenuItem>
-                </LinkContainer>
+                </LinkContainer> */}
               </NavDropdown>
               <IndexLinkContainer to="/grammar">
                 <NavItem className="grammarHelp">Grammatik</NavItem>

--- a/src/main/js/screens/app/components/GakuseiNav.js
+++ b/src/main/js/screens/app/components/GakuseiNav.js
@@ -37,7 +37,8 @@ export class GakuseiNav extends React.Component {
                 <LinkContainer to="/select/flashcards">
                   <MenuItem className="flashcardPlay">Bildkort</MenuItem>
                 </LinkContainer>
-                  {/* <LinkContainer to="/select/kanji">
+                  {/* Remove this comment when feature is done
+                  <LinkContainer to="/select/kanji">
                   <MenuItem className="kanjiPlay">Skriv Kanji</MenuItem>
                 </LinkContainer> */}
               </NavDropdown>


### PR DESCRIPTION
Hides kanji-option from navbar dropdown. Feature is still available via direct link, but I do not think that will be a problem.