### PR TITLE
Db quiz migration

### DIFF
--- a/src/main/resources/db/changelogs/db.changelog_034.yaml
+++ b/src/main/resources/db/changelogs/db.changelog_034.yaml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+- changeSet:
+    id: 34
+    author: sofiaedstrom
+    changes:
+    - sql:
+        comment: insert quizzes from facts
+        sql:  insert into contentschema.quiz (name)
+              select distinct data
+              from contentschema.facts
+              where type = 'quiz';

--- a/src/main/resources/db/changelogs/db.changelog_035.yaml
+++ b/src/main/resources/db/changelogs/db.changelog_035.yaml
@@ -1,0 +1,19 @@
+databaseChangeLog:
+- changeSet:
+    id: 35
+    author: sofiaedstrom
+    changes:
+    - sql:
+        comment: insert quiz_nuggets from facts and nuggets
+        sql:  insert into contentschema.quiz_nugget (question, correct_answer, quiz_ref)
+              select question, correct_answer, quizzes.id as quiz_ref
+              from
+                ( select f.nuggetid, f.data as correct_answer
+                  from contentschema.facts as f
+                  where f.type = 'correct' ) answers,
+                ( select f.nuggetid, f.data as quiz, n.description as question
+                  from contentschema.facts as f, contentschema.nuggets as n
+                  where f.type = 'quiz' and f.nuggetid = n.id ) questions,
+                contentschema.quiz as quizzes
+              where answers.nuggetid = questions.nuggetid
+                    and questions.quiz = quizzes.name;

--- a/src/main/resources/db/changelogs/db.changelog_036.yaml
+++ b/src/main/resources/db/changelogs/db.changelog_036.yaml
@@ -1,0 +1,23 @@
+databaseChangeLog:
+- changeSet:
+    id: 36
+    author: sofiaedstrom
+    changes:
+    - sql:
+        comment: insert incorrect_answers from facts, nuggets and quiz_nuggets
+        sql: insert into contentschema.incorrect_answers (incorrect_answer, quiz_nugget_ref)
+             select incorrect_answer, quiz_nugget_ref
+             from
+               ( select f.nuggetid, f.data as incorrect_answer
+                 from contentschema.facts as f
+                 where f.type = 'incorrect'
+               ) answers,
+               ( select n.id, n.description
+                 from contentschema.nuggets as n
+                 where n.type = 'quiz'
+               ) questions,
+               ( select q.id as quiz_nugget_ref, q.question
+                 from contentschema.quiz_nugget as q
+               ) quiz_nuggets
+             where answers.nuggetid = questions.id
+                   and  questions.description = quiz_nuggets.question;

--- a/src/main/resources/db/changelogs/db.changelog_037.yaml
+++ b/src/main/resources/db/changelogs/db.changelog_037.yaml
@@ -1,0 +1,9 @@
+databaseChangeLog:
+- changeSet:
+    id: 37
+    author: sofiaedstrom
+    changes:
+    - sql:
+        comment: delete quizzes from facts
+        sql:  delete from contentschema.facts
+              where type in('quiz', 'correct', 'incorrect');

--- a/src/main/resources/db/changelogs/db.changelog_038.yaml
+++ b/src/main/resources/db/changelogs/db.changelog_038.yaml
@@ -1,0 +1,9 @@
+databaseChangeLog:
+- changeSet:
+    id: 38
+    author: sofiaedstrom
+    changes:
+    - sql:
+        comment: delete quizzes from nuggets
+        sql:  delete from contentschema.nuggets
+              where type = 'quiz';

--- a/src/main/resources/db/db.changelog-master.yaml
+++ b/src/main/resources/db/db.changelog-master.yaml
@@ -63,3 +63,13 @@ databaseChangeLog:
     file: classpath:db/changelogs/db.changelog_031.yaml
 - include:
     file: classpath:db/changelogs/db.changelog_032.yaml
+- include:
+    file: classpath:db/changelogs/db.changelog_034.yaml
+- include:
+    file: classpath:db/changelogs/db.changelog_035.yaml
+- include:
+    file: classpath:db/changelogs/db.changelog_036.yaml
+- include:
+    file: classpath:db/changelogs/db.changelog_037.yaml
+- include:
+    file: classpath:db/changelogs/db.changelog_038.yaml


### PR DESCRIPTION
changelogs to:
* create Quizzes in quiz table from facts and nuggets with type "quiz"
* create QuizNuggets in quiz_nugget from the quiz ids in quiz table, facts with type "correct" (correct answer) and the description from nuggets with type "quiz" (question)
* create IncorrectAnswers from the quiz_nugget table, facts with type ="incorrect" and nugget description with type "quiz"
* delete the old quiz data from facts and nuggets

**Note**: questions.quiz = quizzes.name in changelog 35, and questions.description = quiz_nuggets.question in changelog 36 only works because questions and quiz names happened to be unique.

**Important**:
If you already have "Den japanska floran" in the new quiz-related tables, remove that data to avoid duplication.