### PR TITLE
Filter out questions that are null

### DIFF
--- a/src/main/java/se/kits/gakusei/util/QuestionHandler.java
+++ b/src/main/java/se/kits/gakusei/util/QuestionHandler.java
@@ -18,6 +18,7 @@ public class QuestionHandler {
         List<Nugget> notHiddenNuggets = nuggets.stream().filter(n -> !n.isHidden()).collect(Collectors.toList());
         List<HashMap<String, Object>> questions = notHiddenNuggets.stream()
                 .map(n -> createQuestion(n, notHiddenNuggets, questionType, answerType))
+                .filter(Objects::nonNull)
                 .collect(Collectors.toList());
         Collections.shuffle(questions);
         if (questions.size() > quantity) {


### PR DESCRIPTION
When creating a question they can be sometimes be set to null. These null-values where not filtered out and could be sent to the user, breaking the front-end in the process.